### PR TITLE
Added onClose method and isClosable method

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React, { useRef } from "react";
 import * as Dockable from "./index.js"
 import styled from "styled-components"
 
@@ -52,6 +52,7 @@ const StyledTabRowInner = styled.div<{
     {
         width: 4px;
         height: 4px;
+        display: none;
     }
 
     &::-webkit-scrollbar-track
@@ -141,6 +142,7 @@ export function ContainerPanel(props: {
 })
 {
     const panelRect: Dockable.LayoutPanel = props.panelRect
+    const refTabRowInner = useRef<HTMLDivElement>(null);
 
     const isActivePanel = props.state.ref.current.activePanel === panelRect.panel
 
@@ -159,6 +161,11 @@ export function ContainerPanel(props: {
                 draggable
                 tabHeight={ props.tabHeight }
                 tabCount={ panelRect.panel.contentList.length }
+                onWheel={(ev) => {
+                  if (refTabRowInner && refTabRowInner.current)
+                    refTabRowInner.current.scrollLeft += ev.deltaY;
+                  ev.preventDefault();
+                }}
                 onMouseDown={ ev => {
                     props.onClickPanel()
                     props.onDragHeader(ev, null)

--- a/src/global.ts
+++ b/src/global.ts
@@ -69,10 +69,12 @@ export function spawnFloatingEphemeral(
 
 export interface ContentContextProps
 {
-    layoutContent: Dockable.LayoutContent
+    layoutContent: Dockable.LayoutContent;
+    content: Dockable.Content;
 
-    setTitle: (title: string) => void
-    setPreferredSize: (w: number, h: number) => void
+    setTitle: (title: string) => void;
+    setPreferredSize: (w: number, h: number) => void;
+    close: () => void;
 }
 
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -60,6 +60,7 @@ export interface Content
 {
     contentId: ContentId
     title: string
+    isClosable?: () => boolean;
     element: JSX.Element
 }
 


### PR DESCRIPTION
I think it could be useful to have a method to close the tab inside the content.
Also, sometimes depending on conditions of the content we may want to forbid the tab to close, so I added an isClosable method on the content that, if defined, the content can control if the tab can be closed or not.
So for example, we want the counter to be closed only when the value is greater than 3 we will do the following:

```
  ctx.content.isClosable = () => {
      return value > 3;
  };
```
If the isClosable doesn't define the close button would work normally.

It can probably be done better, that's just how I would do it.